### PR TITLE
Rudimentary support for identity sockopt

### DIFF
--- a/c_src/erl_czmq.c
+++ b/c_src/erl_czmq.c
@@ -58,6 +58,7 @@ ETERM *ETERM_ERROR_INVALID_CERT;
 #define ZSOCKOPT_RCVHWM 8
 #define ZSOCKOPT_SUBSCRIBE 9
 #define ZSOCKOPT_UNSUBSCRIBE 10
+#define ZSOCKOPT_IDENTITY 11
 
 #define SUCCESS 0
 
@@ -399,6 +400,9 @@ static void handle_zsockopt_get_str(ETERM *args, erl_czmq_state *state) {
     case ZSOCKOPT_CURVE_SERVERKEY:
         val = zsocket_curve_serverkey(socket);
         break;
+    case ZSOCKOPT_IDENTITY:
+        val = zsocket_identity(socket);
+        break;
     default:
         assert(0);
     }
@@ -482,6 +486,9 @@ static void handle_zsockopt_set_str(ETERM *args, erl_czmq_state *state) {
         break;
     case ZSOCKOPT_SUBSCRIBE:
         zsocket_set_subscribe(socket, val);
+        break;
+    case ZSOCKOPT_IDENTITY:
+        zsocket_set_identity(socket, val);
         break;
     case ZSOCKOPT_UNSUBSCRIBE:
         zsocket_set_unsubscribe(socket, val);

--- a/src/czmq.erl
+++ b/src/czmq.erl
@@ -34,6 +34,7 @@
          zsocket_sndhwm/1,
          zsocket_rcvhwm/1,
          zsocket_backlog/1,
+         zsocket_identity/1,
          zsocket_set_zap_domain/2,
          zsocket_set_plain_server/2,
          zsocket_set_plain_username/2,
@@ -43,6 +44,7 @@
          zsocket_set_sndhwm/2,
          zsocket_set_rcvhwm/2,
          zsocket_set_backlog/2,
+         zsocket_set_identity/2,
          zsocket_set_subscribe/2,
          zsocket_set_unsubscribe/2,
          zstr_send/2,
@@ -129,6 +131,7 @@
 -define(ZSOCKOPT_RCVHWM, 8).
 -define(ZSOCKOPT_SUBSCRIBE, 9).
 -define(ZSOCKOPT_UNSUBSCRIBE, 10).
+-define(ZSOCKOPT_IDENTITY, 11).
 
 
 
@@ -256,6 +259,9 @@ zsocket_destroy({Ctx, Socket}) ->
 sockopt_int({Ctx, Socket}, Opt) ->
     gen_server:call(Ctx, {?CMD_ZSOCKOPT_GET_INT, {Socket, Opt}}, infinity).
 
+sockopt_str({Ctx, Socket}, Opt) ->
+    gen_server:call(Ctx, {?CMD_ZSOCKOPT_GET_STR, {Socket, Opt}}, infinity).
+
 zsocket_sndhwm(Sock) ->
     sockopt_int(Sock, ?ZSOCKOPT_SNDHWM).
 
@@ -264,6 +270,9 @@ zsocket_rcvhwm(Sock) ->
 
 zsocket_backlog(Sock) ->
     sockopt_int(Sock, ?ZSOCKOPT_BACKLOG).
+
+zsocket_identity(Sock) ->
+    sockopt_str(Sock, ?ZSOCKOPT_IDENTITY).
 
 sockopt_set_str({Ctx, Socket}, Opt, Str) when is_list(Str) ->
     Args = {Socket, Opt, Str},
@@ -303,6 +312,9 @@ zsocket_set_rcvhwm(Sock, Hwm) ->
 
 zsocket_set_backlog(Sock, Backlog) ->
     sockopt_set_int(Sock, ?ZSOCKOPT_BACKLOG, Backlog).
+
+zsocket_set_identity(Sock, Identity) ->
+    sockopt_set_str(Sock, ?ZSOCKOPT_IDENTITY, Identity).
 
 zsocket_set_subscribe(Sock, Subscribe) ->
     sockopt_set_str(Sock, ?ZSOCKOPT_SUBSCRIBE, Subscribe).

--- a/src/czmq_test.erl
+++ b/src/czmq_test.erl
@@ -356,9 +356,11 @@ router_dealer(Ctx) ->
     {ok, 0} = czmq:zsocket_bind(Router, "inproc://router_dealer"),
 
     Dealer1 = czmq:zsocket_new(Ctx, dealer),
+    ok = czmq:zsocket_set_identity(Dealer1, "dealer-1"),
     ok = czmq:zsocket_connect(Dealer1, "inproc://router_dealer"),
 
     Dealer2 = czmq:zsocket_new(Ctx, dealer),
+    ok = czmq:zsocket_set_identity(Dealer2, "dealer-2"),
     ok = czmq:zsocket_connect(Dealer2, "inproc://router_dealer"),
 
     ok = czmq:zstr_send(Dealer1, "dealer-1 says hello"),
@@ -542,6 +544,11 @@ sockopts(Ctx) ->
     1000 = czmq:zsocket_rcvhwm(Sock),
     czmq:zsocket_set_rcvhwm(Sock, 3000),
     3000 = czmq:zsocket_rcvhwm(Sock),
+
+    %% Identity
+    "" = czmq:zsocket_identity(Sock),
+    czmq:zsocket_set_identity(Sock, "Watson"),
+    "Watson" = czmq:zsocket_identity(Sock),
 
     czmq:zsocket_destroy(Sock),
 


### PR DESCRIPTION
I was working through the Reliability patterns and noticed you can't set the identity of a socket via `czmq`. This remedies that, meaning a `czmq`-based version of the examples in the 0mq guide can be more consistent with the other languages.
