### PR TITLE
rebar build path now supports zmq_gen_benchmark compile first

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
         warnings_as_errors,
         warn_export_all
 ]}.
-
+{erl_first_files, ["src/zmq_gen_benchmark.erl"]}.
 {pre_hooks, [{clean, "rm -fr ebin priv erl_crash.dump"}]}.


### PR DESCRIPTION
Erlang.mk build path supports compiling zmq_gen_benchmark first; solved here: https://github.com/gar1t/erlang-czmq/issues/2

The rebar build path didn't support compiling zmq_gen_benchmark first, so the same error appeared.
