### PR TITLE
fix build with non-static builds

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -37,8 +37,8 @@ PortEnv = case IsStatic of
                   " " ++ Lib("libsodium", "libsodium.a") ++
                   " -lstdc++"}];
     false ->
-        [{"CFLAGS", "-Wall -c -g -02"},
-         {"LDFLAGS", "-lerl_interface -lei -lstdc++ -lpthread -lczmq"}]
+        [{"CFLAGS", "-Wall -c -g -O2"},
+         {"LDFLAGS", "-lerl_interface -lei -lstdc++ -lpthread -lczmq -lzmq"}]
 end,
 
 %% config to build czmq_port and czmq_benchmark


### PR DESCRIPTION
There is a typo in the CFLAGS and zmq is not being linked in. Apparently non-static builds are not being tested? :) If there is a particular reason to discourage linking against system libraries, perhaps this feature should be removed (and in that case linking on x86-64 Linux systems with 32 bit support, where the lib dir is lib64, should be fixed), otherwise, this fixes dynamic linkage builds.
