### PR TITLE
Fixed error message if curl is not installed

### DIFF
--- a/c_src/build_czmq.sh
+++ b/c_src/build_czmq.sh
@@ -6,8 +6,8 @@ if [ "x$CORE_TOP" = "x" ]; then
 fi
 
 CURLBIN=`which curl`
-if ! test -n "CURLBIN"; then
-    display_error "Error: curl is required. Add it to 'PATH'"
+if [ -z "$CURLBIN" ]; then
+    echo "Error: curl is required. Add it to 'PATH'"
     exit 1
 fi
 


### PR DESCRIPTION
build_czmq.sh would display this error if curl was not installed:

```text
./c_src/build_czmq.sh: 72: ./c_src/build_czmq.sh: --progress-bar: not found
```