### PR TITLE
Modified zsocket calls to prevent -Wformat-security compiler errors

### DIFF
--- a/c_src/erl_czmq.c
+++ b/c_src/erl_czmq.c
@@ -246,7 +246,7 @@ static void handle_zsocket_bind(ETERM *args, erl_czmq_state *state) {
 
     ETERM *endpoint_arg = erl_element(2, args);
     char *endpoint = erl_iolist_to_string(endpoint_arg);
-    int rc = zsocket_bind(socket, endpoint);
+    int rc = zsocket_bind(socket, "%s", endpoint);
     if (rc == -1) {
         write_term(ETERM_ERROR_BIND_FAILED, state);
         return;
@@ -275,7 +275,7 @@ static void handle_zsocket_unbind(ETERM *args, erl_czmq_state *state) {
 
     ETERM *endpoint_arg = erl_element(2, args);
     char *endpoint = erl_iolist_to_string(endpoint_arg);
-    int rc = zsocket_unbind(socket, endpoint);
+    int rc = zsocket_unbind(socket, "%s", endpoint);
     if (rc == -1) {
         write_term(ETERM_ERROR_UNBIND_FAILED, state);
         return;
@@ -297,7 +297,7 @@ static void handle_zsocket_connect(ETERM *args, erl_czmq_state *state) {
 
     ETERM *endpoint_arg = erl_element(2, args);
     char *endpoint = erl_iolist_to_string(endpoint_arg);
-    int rc = zsocket_connect(socket, endpoint);
+    int rc = zsocket_connect(socket, "%s", endpoint);
     if (rc == -1) {
         write_term(ETERM_ERROR_CONNECT_FAILED, state);
         return;
@@ -319,7 +319,7 @@ static void handle_zsocket_disconnect(ETERM *args, erl_czmq_state *state) {
 
     ETERM *endpoint_arg = erl_element(2, args);
     char *endpoint = erl_iolist_to_string(endpoint_arg);
-    int rc = zsocket_disconnect(socket, endpoint);
+    int rc = zsocket_disconnect(socket, "%s", endpoint);
     if (rc == -1) {
         write_term(ETERM_ERROR_DISCONNECT_FAILED, state);
         return;


### PR DESCRIPTION
This is an excerpt of compiling on Ubuntu 14.04:

```text
Compiling c_src/erl_czmq.c
c_src/erl_czmq.c: In function ‘handle_zsocket_bind’:
c_src/erl_czmq.c:249:5: warning: format not a string literal and no format arguments [-Wformat-security]
     int rc = zsocket_bind(socket, endpoint);
     ^
c_src/erl_czmq.c: In function ‘handle_zsocket_unbind’:
c_src/erl_czmq.c:278:5: warning: format not a string literal and no format arguments [-Wformat-security]
     int rc = zsocket_unbind(socket, endpoint);
     ^
c_src/erl_czmq.c: In function ‘handle_zsocket_connect’:
c_src/erl_czmq.c:300:5: warning: format not a string literal and no format arguments [-Wformat-security]
     int rc = zsocket_connect(socket, endpoint);
     ^
c_src/erl_czmq.c: In function ‘handle_zsocket_disconnect’:
c_src/erl_czmq.c:322:5: warning: format not a string literal and no format arguments [-Wformat-security]
     int rc = zsocket_disconnect(socket, endpoint);
     ^
```