### PR TITLE
erlang:now() is deprecated. Use erlang:timestamp() instead.

### DIFF
--- a/src/czmq_poller.erl
+++ b/src/czmq_poller.erl
@@ -68,7 +68,7 @@ poll_interval_option(Options) ->
     proplists:get_value(poll_interval, Options, ?DEFAULT_POLL_INTERVAL).
 
 timestamp() ->
-    {M, S, U} = erlang:now(),
+    {M, S, U} = erlang:timestamp(),
     M * 1000000000 + S * 1000 + U div 1000.
 
 %%%===================================================================

--- a/src/zmq_gen_benchmark.erl
+++ b/src/zmq_gen_benchmark.erl
@@ -69,7 +69,7 @@ option(Name, Options, Default) ->
     proplists:get_value(Name, Options, Default).
 
 now_millis() ->
-    {M, S, U} = erlang:now(),
+    {M, S, U} = erlang:timestamp(),
     M * 1000000000 + S * 1000 + U div 1000.
 
 recv_loop(State) ->


### PR DESCRIPTION
See http://www.erlang.org/doc/man/erlang.html#now-0 and
http://www.erlang.org/doc/apps/erts/time_correction.html for more
information.

Attention: These changes are part of erlang as of OTP 18 (ERTS version 7.0).