### PR TITLE
Large messages

### DIFF
--- a/c_src/erl_czmq.h
+++ b/c_src/erl_czmq.h
@@ -7,7 +7,10 @@
 #define ERL_CZMQ_REPLY_BUF_SIZE 10240
 
 typedef struct {
-    byte reply_buf[ERL_CZMQ_REPLY_BUF_SIZE];
+    byte *reply_buf;
+    int reply_buf_size;
+    byte *cmd_buf;
+    int cmd_buf_size;
     zctx_t *ctx;
     vector sockets;
     zauth_t *auth;

--- a/src/czmq.erl
+++ b/src/czmq.erl
@@ -152,7 +152,7 @@ init([]) ->
     {ok, #state{port=Port}}.
 
 start_port() ->
-    open_port({spawn, port_exe()}, [{packet, 2}, binary, exit_status]).
+    open_port({spawn, port_exe()}, [{packet, 4}, binary, exit_status]).
 
 port_exe() ->
     EbinDir = filename:dirname(code:which(?MODULE)),


### PR DESCRIPTION
This PR allows large messages to be sent. It impliments a 4 byte length indicator packet for port communication and an allocated set of command and reply buffers. The initial buffers are allocated to the default size but are grown when needed. There is no logic to handle shrinking buffers.

My use-case is connecting to bitcoin-core and libbitcoin-server, both of which publish ZMQ messages that are up to 1 MB in size. 