### PR TITLE
Adds max buffer size to prevent unbounded memory allocation

### DIFF
--- a/c_src/erl_czmq.c
+++ b/c_src/erl_czmq.c
@@ -79,7 +79,10 @@ typedef void (*cmd_handler)(ETERM*, erl_czmq_state*);
 
 static bool prepare_cmd_buffer(int term_len, erl_czmq_state *state)
 {
-    if (term_len > state->cmd_buf_size) {
+    if (term_len > ERL_CZMQ_MAX_BUF_SIZE) {
+        fprintf(stderr, "term_len %u > max_buf_size %u", term_len, ERL_CZMQ_MAX_BUF_SIZE);
+        exit(EXIT_INTERNAL_ERROR);
+    } else if (term_len > state->cmd_buf_size) {
         state->cmd_buf_size = term_len;
         state->cmd_buf = realloc(state->cmd_buf, term_len);
     }
@@ -89,12 +92,15 @@ static bool prepare_cmd_buffer(int term_len, erl_czmq_state *state)
 
 static bool prepare_reply_buffer(int term_len, erl_czmq_state *state)
 {
-    if (term_len > state->reply_buf_size) {
+    if (term_len > ERL_CZMQ_MAX_BUF_SIZE) {
+        fprintf(stderr, "term_len %u > max_buf_size %u", term_len, ERL_CZMQ_MAX_BUF_SIZE);
+        exit(EXIT_INTERNAL_ERROR);
+    } else if (term_len > state->reply_buf_size) {
         state->reply_buf_size = term_len;
-        state->reply_buf = realloc(state->cmd_buf, term_len);
+        state->reply_buf = realloc(state->reply_buf, term_len);
     }
 
-    return state->cmd_buf && term_len <= state->reply_buf_size;
+    return state->reply_buf && term_len <= state->reply_buf_size;
 }
 
 static int read_exact(byte *buf, int len)

--- a/c_src/erl_czmq.h
+++ b/c_src/erl_czmq.h
@@ -5,6 +5,7 @@
 #include "vector.h"
 
 #define ERL_CZMQ_REPLY_BUF_SIZE 10240
+#define ERL_CZMQ_MAX_BUF_SIZE 10000000
 
 typedef struct {
     byte *reply_buf;

--- a/src/czmq_test.erl
+++ b/src/czmq_test.erl
@@ -563,9 +563,13 @@ sockopts(Ctx) ->
 %%--------------------------------------------------------------------
 
 large_message(Ctx) ->
-    io:format(" * large_message: "),
+    io:format(" * large_messages: ", []),
+    [large_message(Ctx, _N) || _N <- lists:seq(1, 10)],
+    io:format("ok~n").
 
-    Pl1 = ["!" || _ <- lists:seq(1, 1100000)],
+large_message(Ctx, N) ->
+    Pl1 = ["!" || _ <- lists:seq(1,  N * 10000)],
+
     Pub = czmq:zsocket_new(Ctx, pub),
     {ok, 0} = czmq:zsocket_bind(Pub, "inproc://pub_sub"),
 
@@ -582,6 +586,5 @@ large_message(Ctx) ->
     Pl3 = iolist_to_binary(Pl2),
 
     czmq:zsocket_destroy(Sub1),
-    czmq:zsocket_destroy(Pub),
+    czmq:zsocket_destroy(Pub).
 
-    io:format("ok~n").


### PR DESCRIPTION
This adds a simple fixed max buffer size to prevent unbounded memory allocation. It is fixed at 10MB.

This also fixes a nasty copy-paste bug where `prepare_reply_buffer` would reallocate the _cmd_ buffer. :(

 if you'd like the max buffer size to be variable I can include a `set_max_{cmd,reply}_buffer_size` as a port command, _or_ allow the max buffers option to be set when the process is spawned (via port arguments).
