### PR TITLE
Update czmq-2.2.0.tar.gz download location

### DIFF
--- a/c_src/build_czmq.sh
+++ b/c_src/build_czmq.sh
@@ -31,7 +31,7 @@ LIBZMQ_DIR=$STATICLIBS/libzmq
 
 CZMQ_VER=2.2.0
 CZMQ_DISTNAME=czmq-${CZMQ_VER}.tar.gz
-CZMQ_SITE=http://download.zeromq.org/
+CZMQ_SITE=https://archive.org/download/zeromq_czmq_${CZMQ_VER}
 CZMQ_DIR=$STATICLIBS/czmq
 
 [ "$MACHINE" ] || MACHINE=`(uname -m) 2>/dev/null` || MACHINE="unknown"


### PR DESCRIPTION
I was getting the mysterious error:
```
gzip: /home/vagrant/repo/elixir-playing/zmqsender/deps/czmq/c_src/.dists/czmq-2.2.0.tar.gz: not in gzip format
```
Looking inside the file, I found it contained `Not Found`.

Take a look at [http://download.zeromq.org/](http://download.zeromq.org/) and you'lll see the download URL has changed to `https://archive.org/download/zeromq_czmq_2.2.0/czmq-2.2.0.tar.gz`

As a side point, this rather cryptic error would have been easier to debug if the script exited on the failed `curl` command rather than ploughing on. It would be worth considering changing the shebang to `/bin/sh -e` rather than `/bin/sh`.

Cheers,
Paul