### PR TITLE
Update zeromq download site

### DIFF
--- a/c_src/build_czmq.sh
+++ b/c_src/build_czmq.sh
@@ -26,7 +26,7 @@ LIBSODIUM_DIR=$STATICLIBS/libsodium
 
 LIBZMQ_VER=4.0.4
 LIBZMQ_DISTNAME=zeromq-${LIBZMQ_VER}.tar.gz
-LIBZMQ_SITE=http://download.zeromq.org
+LIBZMQ_SITE=https://archive.org/download/zeromq_${LIBZMQ_VER}
 LIBZMQ_DIR=$STATICLIBS/libzmq
 
 CZMQ_VER=2.2.0


### PR DESCRIPTION
Currently, the compiling czmq fails as the zeromq library is no longer available at http://download.zeromq.org.

Download links seemed to have been moved to https://archive.org/download/zeromq_4.0.4 based on this thread I found: https://mid.mail-archive.com/search?l=zeromq-dev@lists.zeromq.org&q=subject:%22%5C%5Bzeromq%5C-dev%5C%5D+download.zeromq.org%5C%3A+last+call%22&o=newest&f=1